### PR TITLE
Added a confirmation box when new Dart files are created

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const { createHandler, renameHandler } = require('./src/handlers');
+const { isTestFile } = require('./src/helpers');
 
 function activate(context) {
 	vscode.window.showInformationMessage("Flutter Mimic Active!");
@@ -9,33 +10,42 @@ function activate(context) {
 	watcher.ignoreCreateEvents = false;
 	watcher.ignoreChangeEvents = true;
 	watcher.ignoreDeleteEvents = true;
-	
-	watcher.onDidCreate((e)=>{
-		if(nextActionIsRename){ 
+
+	watcher.onDidCreate((e) => {
+		if (nextActionIsRename) {
 			nextActionIsRename = false;
-		}else{
-			createHandler(e);
-			vscode.window.showInformationMessage("Flutter Mimic: File create!")
+		} else {
+			if (!e.path.endsWith('test.dart')) {
+				vscode.window.showInformationMessage(
+					"Flutter Mimic: You just created a new Dart file. Do you want to create a mirrored test file?",
+					...["Yes", "No"]
+				).then((answer) => {
+					answer === "Yes"
+						? createHandler(e, () => { vscode.window.showInformationMessage("Flutter Mimic: File create!") })
+						: vscode.window.showInformationMessage("Flutter Mimic: Nothing done!")
+
+				})
+			}
 		}
 	})
 
-	vscode.workspace.onDidRenameFiles((e)=>{
+	vscode.workspace.onDidRenameFiles((e) => {
 		nextActionIsRename = true;
-		e.files.forEach((file)=>{
+		e.files.forEach((file) => {
 			renameHandler(file);
 		})
 		vscode.window.showInformationMessage("Adjusment made");
 	})
 
-	vscode.workspace.onDidDeleteFiles((e)=>{
+	vscode.workspace.onDidDeleteFiles((e) => {
 		vscode.window.showInformationMessage("Flutter Mimic: Files arent deleted automatic.");
 	});
 
 	context.subscriptions.push(watcher);
-} 
+}
 
 // this method is called when your extension is deactivated
-function deactivate() {}
+function deactivate() { }
 
 module.exports = {
 	activate,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es6",
-		"checkJs": true,  /* Typecheck .js files. */
+		"checkJs": true, /* Typecheck .js files. */
 		"lib": [
 			"es6"
 		]

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -2,67 +2,68 @@ const mkdirp = require('mkdirp');
 const vscode = require('vscode');
 const { isDartFile, isFolder, isOnLib, isTestFile } = require("./helpers");
 
-exports.renameHandler = (file)=>{
+exports.renameHandler = (file) => {
     let newUri = file.newUri.path;
     let oldUri = file.oldUri.path;
 
-    if(isOnLib(oldUri)){
-        newUri = newUri.replace("/lib/","/test/")
-        oldUri = oldUri.replace("/lib/","/test/")
-    }else{
-        newUri = newUri.replace("/test/","/lib/");
-        oldUri = oldUri.replace("/test/","/lib/");
+    if (isOnLib(oldUri)) {
+        newUri = newUri.replace("/lib/", "/test/")
+        oldUri = oldUri.replace("/lib/", "/test/")
+    } else {
+        newUri = newUri.replace("/test/", "/lib/");
+        oldUri = oldUri.replace("/test/", "/lib/");
     }
 
-    if(isDartFile(oldUri)){
-        if(isTestFile(oldUri)){
-            newUri = newUri.replace("_test.dart",".dart");
-            oldUri = oldUri.replace("_test.dart",".dart");
-        }else{
-            oldUri = oldUri.replace(".dart","_test.dart");
-            newUri = newUri.replace(".dart","_test.dart");
+    if (isDartFile(oldUri)) {
+        if (isTestFile(oldUri)) {
+            newUri = newUri.replace("_test.dart", ".dart");
+            oldUri = oldUri.replace("_test.dart", ".dart");
+        } else {
+            oldUri = oldUri.replace(".dart", "_test.dart");
+            newUri = newUri.replace(".dart", "_test.dart");
         }
     }
 
     renameFile(oldUri, newUri);
 }
 
-exports.createHandler = (e)=>{
+exports.createHandler = (e, onSuccess) => {
     let path = e.path;
 
-    if(isOnLib(path)){
-        path = path.replace("/lib/","/test/");
-    }else{
-        path = path.replace("/test/","/lib/");
+    if (isOnLib(path)) {
+        path = path.replace("/lib/", "/test/");
+    } else {
+        path = path.replace("/test/", "/lib/");
     }
-    
-    if(isFolder(path)){
+
+    if (isFolder(path)) {
         createFolder(path);
         return;
     }
-    
-    if(isDartFile(path)){
-        if(isTestFile(path)){
-            path = path.replace('_test.dart','.dart');
-        }else{
-            path = path.replace('.dart','_test.dart');
+
+    if (isDartFile(path)) {
+        if (isTestFile(path)) {
+            path = path.replace('_test.dart', '.dart');
+        } else {
+            path = path.replace('.dart', '_test.dart');
         }
-        createFile(path);
+        createFile(path, onSuccess);
     }
 };
 
-const createFolder = (filePath)=>{
+const createFolder = (filePath) => {
     mkdirp(vscode.Uri.parse(filePath).fsPath);
 }
 
-const createFile = (filePath) => {
+const createFile = (filePath, onSuccess) => {
     let wsedit = new vscode.WorkspaceEdit();
-    wsedit.createFile(vscode.Uri.parse(filePath),{ignoreIfExists:true});
+    wsedit.createFile(vscode.Uri.parse(filePath), { ignoreIfExists: true });
     vscode.workspace.applyEdit(wsedit);
+    onSuccess()
 }
 
 const renameFile = (oldUri, newUri) => {
     let wsedit = new vscode.WorkspaceEdit();
-    wsedit.renameFile(vscode.Uri.parse(oldUri),vscode.Uri.parse(newUri),{ignoreIfExists: false});
+    wsedit.renameFile(vscode.Uri.parse(oldUri), vscode.Uri.parse(newUri), { ignoreIfExists: false });
     vscode.workspace.applyEdit(wsedit);
 }


### PR DESCRIPTION
While using this extension, I realized that all files are mirrored by default. I don't want to create a test file for widgets, for example, since I only write unit tests. So, I added a confirmation box, and the test file is created only when I want.

![image](https://user-images.githubusercontent.com/20285104/130147477-90cf0f8e-0a71-4722-b12f-8e70158062be.png)

![image](https://user-images.githubusercontent.com/20285104/130147701-e2c25a9c-af1c-49a8-8510-ed64ef6dfb22.png)
